### PR TITLE
Do not unconditionally use -Wall

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ apache_LIBEXECDIR=`@apxs@ -q LIBEXECDIR`
 
 ## Define the source file for the module
 libmodmarkdown_la_SOURCES = mod_markdown.c
-libmodmarkdown_la_CFLAGS = -Wall $(apache_CFLAGS) -I@discount_dir@/include
+libmodmarkdown_la_CFLAGS = $(apache_CFLAGS) -I@discount_dir@/include
 libmodmarkdown_la_LDFLAGS = -L@discount_dir@/lib -lmarkdown
 
 ## Define that an include directory is required.


### PR DESCRIPTION
-Wall should not be added unconditionally as non-gcc compilers like Sun Studio bail out on this flag.