### PR TITLE
Output <title> element even when no title is available, fixes #18

### DIFF
--- a/mod_markdown.c
+++ b/mod_markdown.c
@@ -96,6 +96,8 @@ void markdown_output(MMIOT *doc, request_rec *r)
     title = mkd_doc_title(doc);
     if (title) {
         ap_rprintf(r, "<title>%s</title>\n", title);
+    }else{
+        ap_rprintf(r, "<title></title>\n");
     }
     ap_rputs("</head>\n", r);
     ap_rputs("<body>\n", r);


### PR DESCRIPTION
According to the W3C HTML(4) specification:

```
Every HTML document **must** have a TITLE element in the HEAD section.
```

So add an empty one when we have no title available.

Refer-to: The global structure of an HTML document &lt;<https://www.w3.org/TR/html401/struct/global.html#h-7.4.2>&gt;
Signed-off-by: 林博仁 &lt;<Buo.Ren.Lin@gmail.com>&gt;