### PR TITLE
Retval

### DIFF
--- a/mod_markdown.c
+++ b/mod_markdown.c
@@ -344,6 +344,8 @@ static int markdown_doc_footer(request_rec *r, markdown_conf *conf)
         ap_rputs("</body>\n", r);
         ap_rputs("</html>\n", r);
     }
+
+	return OK;
 }
 
 /* The markdown handler */

--- a/mod_markdown.c
+++ b/mod_markdown.c
@@ -345,7 +345,7 @@ static int markdown_doc_footer(request_rec *r, markdown_conf *conf)
         ap_rputs("</html>\n", r);
     }
 
-	return OK;
+    return OK;
 }
 
 /* The markdown handler */


### PR DESCRIPTION
Return a value from markdown_doc_footer.

The lack of return value makes the return value undefined, making the module fail of MarkdownFooterFile is specified.
